### PR TITLE
Use Cake.CoreCLR to build instead of Mono

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,65 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+*.sh text eol=lf
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/README.md
+++ b/README.md
@@ -71,6 +71,32 @@ Then the fun part starts, you will need to implement the following ports:
 * `IServiceStatusProvider` to get status of the service
 * `IServiceDependenciesProvider` to determine the dependencies of a service
 
+## Building
+
+Voltmeter uses [Cake](https://cakebuild.net) to build, test and package. You can run this on both Windows, Linux and macOS.
+
+On Windows:
+
+```PowerShell
+> .\build.ps1 -Target Build-Release -Configuration Release
+```
+
+On Linux/macOS:
+
+```bash
+> ./build.sh --target=Build-Release --configuration=Release
+```
+
+Note that on Linux, the `build.sh` script automatically installs dependencies through `apt-get` so YMMV on other Linuxes. 
+The dependencies it looks for are: `curl`, `unzip`, `dotnet` and `git`. If you already have them on your system you'll be fine.
+
+You can also run the build inside a docker container if you want. In that case do:
+
+```bash
+> docker run --rm -it -v c:\git\Voltmeter:/tmp/repo -w "/tmp/repo" ubuntu:18.04 ./build.sh --target=Build-Release --configuration=Release
+```
+This will create a binary release of Voltmeter in `/artifacts`
+
 ## Models
 
 | Model | Purpose |

--- a/build.sh
+++ b/build.sh
@@ -1,117 +1,76 @@
 #!/usr/bin/env bash
-
-##########################################################################
-# This is the Cake bootstrapper script for Linux and OS X.
-# This file was downloaded from https://github.com/cake-build/resources
-# Feel free to change this file to fit your needs.
-##########################################################################
-
 # Define directories.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 TOOLS_DIR=$SCRIPT_DIR/tools
-ADDINS_DIR=$TOOLS_DIR/Addins
-MODULES_DIR=$TOOLS_DIR/Modules
-NUGET_EXE=$TOOLS_DIR/nuget.exe
-CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
-PACKAGES_CONFIG=$TOOLS_DIR/packages.config
-PACKAGES_CONFIG_MD5=$TOOLS_DIR/packages.config.md5sum
-ADDINS_PACKAGES_CONFIG=$ADDINS_DIR/packages.config
-MODULES_PACKAGES_CONFIG=$MODULES_DIR/packages.config
+CAKE_VERSION=0.31.0
+CAKE_DLL=$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION/Cake.dll
 
-# Define md5sum or md5 depending on Linux/OSX
-MD5_EXE=
-if [[ "$(uname -s)" == "Darwin" ]]; then
-    MD5_EXE="md5 -r"
-else
-    MD5_EXE="md5sum"
-fi
-
-# Define default arguments.
-SCRIPT="build.cake"
-CAKE_ARGUMENTS=()
-
-# Parse arguments.
-for i in "$@"; do
-    case $1 in
-        -s|--script) SCRIPT="$2"; shift ;;
-        --) shift; CAKE_ARGUMENTS+=("$@"); break ;;
-        *) CAKE_ARGUMENTS+=("$1") ;;
-    esac
-    shift
-done
+# Disable dotnet sdk telemetry
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 # Make sure the tools folder exist.
 if [ ! -d "$TOOLS_DIR" ]; then
   mkdir "$TOOLS_DIR"
 fi
 
-# Make sure that packages.config exist.
-if [ ! -f "$TOOLS_DIR/packages.config" ]; then
-    echo "Downloading packages.config..."
-    curl -Lsfo "$TOOLS_DIR/packages.config" https://cakebuild.net/download/bootstrapper/packages
-    if [ $? -ne 0 ]; then
-        echo "An error occurred while downloading packages.config."
-        exit 1
+
+###########################################################################
+# INSTALL PREREQUISITES
+###########################################################################
+
+if [ `uname -s` = 'Linux' ]
+then
+    apt-get update
+
+    if [ -z `which curl` ]
+    then
+        echo "curl is missing, installing..."
+        apt-get install -y curl
+    fi
+    
+    if [ -z `which unzip` ]
+    then
+        echo "unzip is missing, installing..."
+        apt-get install -y unzip
+    fi
+
+    if [ -z `which git` ]
+    then
+        echo "git is missing, installing..."
+        apt-get install -y git
+    fi
+
+    if [ -z `which dotnet` ]
+    then
+        curl -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
+        dpkg -i /tmp/packages-microsoft-prod.deb
+
+        apt-get update
+        apt-get install -y dotnet-sdk-2.1
     fi
 fi
 
-# Download NuGet if it does not exist.
-if [ ! -f "$NUGET_EXE" ]; then
-    echo "Downloading NuGet..."
-    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+###########################################################################
+# INSTALL CAKE
+###########################################################################
+
+if [ ! -f "$CAKE_DLL" ]; then
+    curl -Lsfo Cake.CoreCLR.zip "https://www.nuget.org/api/v2/package/Cake.CoreCLR/$CAKE_VERSION" && unzip -q Cake.CoreCLR.zip -d "$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION" && rm -f Cake.CoreCLR.zip
     if [ $? -ne 0 ]; then
-        echo "An error occurred while downloading nuget.exe."
+        echo "An error occured while installing Cake."
         exit 1
     fi
-fi
-
-# Restore tools from NuGet.
-pushd "$TOOLS_DIR" >/dev/null
-if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat "$PACKAGES_CONFIG_MD5" | sed 's/\r$//' )" != "$( $MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' )" ]; then
-    find . -type d ! -name . ! -name 'Cake.Bakery' | xargs rm -rf
-fi
-
-mono "$NUGET_EXE" install -ExcludeVersion
-if [ $? -ne 0 ]; then
-    echo "Could not restore NuGet tools."
-    exit 1
-fi
-
-$MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' >| "$PACKAGES_CONFIG_MD5"
-
-popd >/dev/null
-
-# Restore addins from NuGet.
-if [ -f "$ADDINS_PACKAGES_CONFIG" ]; then
-    pushd "$ADDINS_DIR" >/dev/null
-
-    mono "$NUGET_EXE" install -ExcludeVersion
-    if [ $? -ne 0 ]; then
-        echo "Could not restore NuGet addins."
-        exit 1
-    fi
-
-    popd >/dev/null
-fi
-
-# Restore modules from NuGet.
-if [ -f "$MODULES_PACKAGES_CONFIG" ]; then
-    pushd "$MODULES_DIR" >/dev/null
-
-    mono "$NUGET_EXE" install -ExcludeVersion
-    if [ $? -ne 0 ]; then
-        echo "Could not restore NuGet modules."
-        exit 1
-    fi
-
-    popd >/dev/null
 fi
 
 # Make sure that Cake has been installed.
-if [ ! -f "$CAKE_EXE" ]; then
-    echo "Could not find Cake.exe at '$CAKE_EXE'."
+if [ ! -f "$CAKE_DLL" ]; then
+    echo "Could not find Cake.exe at '$CAKE_DLL'."
     exit 1
 fi
 
+###########################################################################
+# RUN BUILD SCRIPT
+###########################################################################
+
 # Start Cake
-exec mono "$CAKE_EXE" $SCRIPT "${CAKE_ARGUMENTS[@]}"
+exec dotnet "$CAKE_DLL" "$@"


### PR DESCRIPTION
Change the `build.sh` script to use Cake.CoreCLR to execute the build script. Currently only for Linux, it assumes that on macOS all necessary tools are present.

The README has also been updated with build instructions